### PR TITLE
Adds new "Does My Game Work" command and functionality in ~gs command to return URL of inputted argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ shuttle-runtime = "0.43.0"
 
 [dependencies.serenity]
 version = "0.12.1"
+features = ["collector"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # uisuki
 Whisky's Discord Log Bot
+
+## Instructions for running locally
+You'll need to have a Discord application created, and a bot under that application added to a server. You can create that [here](https://discord.com/developers/applications).
+
+After you have completed the above steps, do the following:
+```
+// Clone into the uisuki repository
+git clone https://github.com/Whisky-App/uisuki.git
+
+// cd to the uisuki directory
+cd uisuki
+
+// Inside the uisuki directory, create a Secrets.toml file, and add the following line,
+// replacing <token> with the private token of the bot.
+DISCORD_TOKEN="<token>"
+
+// Start the bot
+cargo shuttle run
+```

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ You'll need to have a Discord application created, and a bot under that applicat
 
 After you have completed the above steps, do the following:
 ```
-// Clone into the uisuki repository
+//  Clone into the uisuki repository
 git clone https://github.com/Whisky-App/uisuki.git
 
-// cd to the uisuki directory
+//  cd to the uisuki directory
 cd uisuki
 
-// Inside the uisuki directory, create a Secrets.toml file, and add the following line,
-// replacing <token> with the private token of the bot.
-DISCORD_TOKEN="<token>"
+/* 
+    Inside the uisuki directory, create a Secrets.toml file, and add the following line,
+    replacing <token> with the private token of the bot.
+    DISCORD_TOKEN="<token>"
+*/
 
-// Start the bot
+//  Start the bot
 cargo shuttle run
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Whisky's Discord Log Bot
 
 ## Instructions for running locally
-You'll need to have a Discord application created, and a bot under that application added to a server. You can create that [here](https://discord.com/developers/applications).
+You'll need to have a Discord application created, and a bot under that application added to a server. You can create that [here](https://discord.com/developers/applications). Ensure the bot has the proper "Privileged Gateway Intents" enabled.
 
 After you have completed the above steps, do the following:
 ```
@@ -14,7 +14,8 @@ cd uisuki
 
 /* 
     Inside the uisuki directory, create a Secrets.toml file, and add the following line,
-    replacing <token> with the private token of the bot.
+    replacing <token> with the private token of the bot:
+
     DISCORD_TOKEN="<token>"
 */
 

--- a/src/commands/does_my_game_work.rs
+++ b/src/commands/does_my_game_work.rs
@@ -16,16 +16,16 @@ async fn does_my_game_work(ctx: &Context, msg: &Message) -> CommandResult {
 
     let reply = String::from("Does your game work? Check https://docs.getwhisky.app/game-support/ first, and search to see if anyone else has this same issue in this Discord or the GitHub repository.
 
-    Can't find your game from those sources? Check here:
-    https://www.protondb.com/
-    https://appdb.winehq.org/
-    https://www.codeweavers.com/compatibility
-    https://www.applegamingwiki.com/wiki/Home
-    https://www.pcgamingwiki.com/wiki/Home
-    
-    If you've checked all of these places and still can't find an answer, feel free to create a support post in #support !
+Can't find your game from those sources? Check here:
+https://www.protondb.com/
+https://appdb.winehq.org/
+https://www.codeweavers.com/compatibility
+https://www.applegamingwiki.com/wiki/Home
+https://www.pcgamingwiki.com/wiki/Home
 
-    As a reminder: Most games with EasyAntiCheat and most other anti-cheats will **NOT** work without workarounds.");
+If you've checked all of these places and still can't find an answer, feel free to create a support post in #support !
+
+As a reminder: Most games with EasyAntiCheat and most other anti-cheats will **NOT** work without workarounds.");
 
     let mut reply_msg = msg.reply(&ctx, reply).await?;
 

--- a/src/commands/does_my_game_work.rs
+++ b/src/commands/does_my_game_work.rs
@@ -1,0 +1,49 @@
+/*
+    created by hahayupgit 2024/4/16
+    desc: command for if someone asks "does x game work?"
+*/
+use serenity::all::EditMessage;
+use serenity::futures::StreamExt;
+use serenity::framework::standard::macros::command;
+use serenity::framework::standard::CommandResult;
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+use std::time::Duration;
+
+#[command]
+#[aliases("dmgw")]
+async fn does_my_game_work(ctx: &Context, msg: &Message) -> CommandResult {
+
+    let reply = String::from("Does your game work? Check https://docs.getwhisky.app/game-support/ first, and search to see if anyone else has this same issue in this Discord or the GitHub repository.
+
+    Can't find your game from those sources? Check here:
+    https://www.protondb.com/
+    https://appdb.winehq.org/
+    https://www.codeweavers.com/compatibility
+    https://www.applegamingwiki.com/wiki/Home
+    https://www.pcgamingwiki.com/wiki/Home
+    
+    If you've checked all of these places and still can't find an answer, feel free to create a support post in #support !
+
+    As a reminder: Most games with EasyAntiCheat and most other anti-cheats will **NOT** work without workarounds.");
+
+    let mut reply_msg = msg.reply(&ctx, reply).await?;
+
+    // below code pulled directly from serenity-rs documentation
+    // can be found here: https://docs.rs/serenity/latest/serenity/builder/struct.EditMessage.html#method.suppress_embeds
+
+    // When the embed appears, a MessageUpdate event is sent and we suppress 
+    // the embed. No MessageUpdate event is sent if the message contains no 
+    // embeddable link or if the link has been posted before and is still 
+    // cached in Discord's servers (in which case the embed appears 
+    // immediately), no MessageUpdate event is sent. To not wait forever in
+    // those cases, a timeout of 2000ms was added.
+    let msg_id = reply_msg.id;
+    let mut message_updates = serenity::collector::collect(&ctx.shard, move |ev| match ev {
+        Event::MessageUpdate(x) if x.id == msg_id => Some(()),
+        _ => None,
+    });
+    let _ = tokio::time::timeout(Duration::from_millis(2000), message_updates.next()).await;
+    reply_msg.edit(&ctx, EditMessage::new().suppress_embeds(true)).await?;
+    Ok(())
+}

--- a/src/commands/game_support.rs
+++ b/src/commands/game_support.rs
@@ -1,3 +1,8 @@
+/*
+    modified by hahayupgit 2024/4/9
+    desc: added ability to return webpage of inputted argument
+*/
+
 use serenity::framework::standard::macros::command;
 use serenity::framework::standard::CommandResult;
 use serenity::model::prelude::*;
@@ -6,6 +11,46 @@ use serenity::prelude::*;
 #[command]
 #[aliases("gs")]
 async fn game_support(ctx: &Context, msg: &Message) -> CommandResult {
-    msg.reply(&ctx, "https://docs.getwhisky.app/game-support").await?;
+
+    // String containing default response
+    let mut site = String::from("https://docs.getwhisky.app/game-support/");
+
+    // command stripped of leading and trailing whitespace
+    let mut message = msg.content.trim().to_string();
+
+    // if command is only "~gs" or "~game_support", reply with default response
+    if message == "~gs" || message == "~game_support" {
+        msg.reply(&ctx, site).await?;
+    }
+
+    // if command has arguments
+    else {
+
+        // determine which command was said & remove command given
+        if message.contains("~gs") {
+            message = message.replace("~gs ", "");
+        }
+        else {
+            message = message.replace("~game_support ", "");
+        }
+
+        // concatenate the argument to the original default response & reply
+        site.push_str(&message);
+        msg.reply(&ctx, site).await?;
+
+        /*
+            NOTE: this method does not have any checks for
+            URLs that are incorrect. this should not pose
+            any security threats, however may make it harder
+            for people who don't know the exact URL of longer games
+            (i.e. Star Wars Jedi: Fallen Order being sw-fallen-order
+            or Geometry Wars 3: Dimensions Evolved being gw3-dimensions-evolved).
+
+            if i was a better developer, i'd figure out how to handle
+            this. but i'm not, so i may return to this in a future change.
+
+            - hahayupgit 2024/4/9 
+         */
+    }
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod ping;
 pub mod say;
+pub mod does_my_game_work;
 pub mod game_support;
 pub mod github;
 pub mod website;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,13 @@ use crate::commands::discord::*;
 use crate::commands::game_support::*;
 use crate::commands::github::*;
 use crate::commands::website::*;
+use crate::commands::does_my_game_work::*;
 
 pub mod header;
 mod commands;
 
 #[group]
-#[commands(ping, say, discord, game_support, github, website)]
+#[commands(ping, say, discord, game_support, github, website, does_my_game_work)]
 struct General;
 
 struct Handler;


### PR DESCRIPTION
## ~dmgw or ~does_my_game_work command works as the following:
![Screenshot 2024-04-16 at 7 01 25 PM](https://github.com/Whisky-App/uisuki/assets/161992562/39d0c3ed-bd33-4fc0-81ad-e16626868e89)

Contains code to automatically remove any embeds generated by the command

## ~gs or ~game_support command works as the following: 
![Screenshot 2024-04-09 at 6 38 29 PM](https://github.com/Whisky-App/uisuki/assets/161992562/52171c4c-7c32-4682-a42f-176381586295)

Nothing fancy, just direct concatenation. I want to add the ability to check against the current list of documented games however I don't know how to go about doing that just yet, so that's a task for the future.